### PR TITLE
ade_prepro.sh: Add missing continuation char

### DIFF
--- a/ade_prepro.sh
+++ b/ade_prepro.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 
-python ade_prepro.py
+python ade_prepro.py \
   --data_dir "data/ADR" \
   --output_dir "data/canonical_data" \
 


### PR DESCRIPTION
This pr adds a continuation char on line 4, otherwise bash will treat `--data_dir` on line 5 as a command.